### PR TITLE
Gen step wise ONNX graph generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,24 @@ options:
 https://huggingface.co/docs/transformers/model_doc/llama
 ```
 $ python3 -m optimum.litmus.nlp.llama --help
-usage: FuriosaAI litmus LLaMA using HF Optimum API. [-h] [--size {7b,13b,30b,65b}] output_dir
+usage: FuriosaAI litmus LLaMA using HF Optimum API. [-h] [--model-size {7b,13b,30b,65b}] [--batch-size BATCH_SIZE] [--input-len INPUT_LEN] [--gen-step GEN_STEP]
+                                                    [--task {text-generation-with-past}]
+                                                    output_dir
 
 positional arguments:
   output_dir            path to directory to save outputs
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
-  --size {7b,13b,30b,65b}, -s {7b,13b,30b,65b}
+  --model-size {7b,13b,30b,65b}, -s {7b,13b,30b,65b}
                         available model sizes
+  --batch-size BATCH_SIZE, -b BATCH_SIZE
+                        Batch size for model inputs
+  --input-len INPUT_LEN
+                        Length of input prommpt
+  --gen-step GEN_STEP   Generation step to simplify onnx graph
+  --task {text-generation-with-past}
+                        Task to export model for
 ```
 
 [![ONNX Runtime](https://github.com/huggingface/optimum/actions/workflows/test_onnxruntime.yml/badge.svg)](https://github.com/huggingface/optimum/actions/workflows/test_onnxruntime.yml)

--- a/README.md
+++ b/README.md
@@ -62,16 +62,24 @@ optional arguments:
 ### OPT
 https://huggingface.co/docs/transformers/model_doc/opt
 ```
-$ python3 -m optimum.litmus.nlp.opt --help
-usage: FuriosaAI litmus OPT using HF Optimum API. [-h] [--size {125m,350m,1.3b,2.7b,6.7b,30b,66b}] output_dir
+usage: FuriosaAI litmus OPT using HF Optimum API. [-h] [--model-size {125m,350m,1.3b,2.7b,6.7b,30b,66b}] [--batch-size BATCH_SIZE] [--input-len INPUT_LEN] [--gen-step GEN_STEP]
+                                                  [--task {text-generation-with-past}]
+                                                  output_dir
 
 positional arguments:
   output_dir            path to directory to save outputs
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
-  --size {125m,350m,1.3b,2.7b,6.7b,30b,66b}, -s {125m,350m,1.3b,2.7b,6.7b,30b,66b}
+  --model-size {125m,350m,1.3b,2.7b,6.7b,30b,66b}, -s {125m,350m,1.3b,2.7b,6.7b,30b,66b}
                         available model sizes
+  --batch-size BATCH_SIZE, -b BATCH_SIZE
+                        Batch size for model inputs
+  --input-len INPUT_LEN
+                        Length of input prommpt
+  --gen-step GEN_STEP   Generation step to simplify onnx graph
+  --task {text-generation-with-past}
+                        Task to export model for
 ```
 
 ### LLaMA

--- a/README.md
+++ b/README.md
@@ -40,15 +40,23 @@ https://huggingface.co/docs/transformers/model_doc/gpt2
 
 ```
 $ python3 -m optimum.litmus.nlp.gpt2 --help
-usage: FuriosaAI litmus GPT2 using HF Optimum API. [-h] [--size {s,m,l,xl}] output_dir
+usage: FuriosaAI litmus GPT2 using HF Optimum API. [-h] [--model-size {s,m,l,xl}] [--batch-size BATCH_SIZE] [--input-len INPUT_LEN] [--gen-step GEN_STEP] [--task {text-generation-with-past}]
+                                                   output_dir
 
 positional arguments:
   output_dir            path to directory to save outputs
 
 optional arguments:
   -h, --help            show this help message and exit
-  --size {s,m,l,xl}, -s {s,m,l,xl}
+  --model-size {s,m,l,xl}, -s {s,m,l,xl}
                         available model sizes
+  --batch-size BATCH_SIZE, -b BATCH_SIZE
+                        Batch size for model inputs
+  --input-len INPUT_LEN
+                        Length of input prommpt
+  --gen-step GEN_STEP   Generation step to simplify onnx graph
+  --task {text-generation-with-past}
+                        Task to export model for
 ```
 
 ### OPT

--- a/README.md
+++ b/README.md
@@ -15,15 +15,24 @@ https://huggingface.co/docs/transformers/model_doc/gpt_neo
 
 ```
 $ python3 -m optimum.litmus.nlp.gpt-neo --help
-usage: FuriosaAI litmus GPT Neo using HF Optimum API. [-h] [--size {125m,1.3b,2.7b}] output_dir
+usage: FuriosaAI litmus GPT Neo using HF Optimum API. [-h] [--model-size {125m,1.3b,2.7b}] [--batch-size BATCH_SIZE] [--input-len INPUT_LEN] [--gen-step GEN_STEP]
+                                                      [--task {text-generation-with-past}]
+                                                      output_dir
 
 positional arguments:
   output_dir            path to directory to save outputs
 
 optional arguments:
   -h, --help            show this help message and exit
-  --size {125m,1.3b,2.7b}, -s {125m,1.3b,2.7b}
+  --model-size {125m,1.3b,2.7b}, -s {125m,1.3b,2.7b}
                         available model sizes
+  --batch-size BATCH_SIZE, -b BATCH_SIZE
+                        Batch size for model inputs
+  --input-len INPUT_LEN
+                        Length of input prommpt
+  --gen-step GEN_STEP   Generation step to simplify onnx graph
+  --task {text-generation-with-past}
+                        Task to export model for
 ```
 
 ### GPT2

--- a/optimum/litmus/__init__.py
+++ b/optimum/litmus/__init__.py
@@ -2,6 +2,8 @@ import copy
 from pathlib import Path
 from typing import Dict, List, Union
 
+import onnxruntime as ort
+
 from furiosa.tools.compiler.api import compile
 import onnx
 from optimum.exporters.onnx import main_export
@@ -10,6 +12,8 @@ from optimum.litmus import onnxsim, utils
 TARGET_IR = "dfg"
 TARGET_NPU = "warboy-b0"
 
+# set default onnxruntime looging level 3: Error to suppress warnings(2: Warning)
+ort.set_default_logger_severity(3)
 export_onnx = main_export
 
 

--- a/optimum/litmus/__init__.py
+++ b/optimum/litmus/__init__.py
@@ -1,17 +1,11 @@
 import copy
-import os
-import sys
-import tempfile
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Union
 
-import onnx
-import onnxruntime as ort
 from furiosa.tools.compiler.api import compile
-from onnx.external_data_helper import load_external_data_for_model
-from onnxsim import model_info, onnx_simplifier
+import onnx
 from optimum.exporters.onnx import main_export
-
+from optimum.litmus import onnxsim, utils
 
 TARGET_IR = "dfg"
 TARGET_NPU = "warboy-b0"
@@ -19,84 +13,51 @@ TARGET_NPU = "warboy-b0"
 export_onnx = main_export
 
 
-def simplify_onnx(input_model: Path, output_model: Path, overwrite_input_shapes: Dict[str, List[int]]) -> None:
-    # https://github.com/daquexian/onnx-simplifier/blob/v0.4.28/onnxsim/onnx_simplifier.py#L479-L521
-    print("Simplifying...")
+def simplify_onnx(
+    input_model: Union[Path, onnx.ModelProto],
+    output_model: Path,
+    overwrite_input_shapes: Dict[str, List[int]],
+) -> onnx.ModelProto:
+    model_orig = utils.load_onnx(input_model) if isinstance(input_model, Path) else input_model
+    model_copy = copy.deepcopy(model_orig)
 
-    model = optimize_with_onnxruntime(input_model)
-
-    model_opt, check_ok = onnx_simplifier.simplify(
-        model,
-        check_n=1,
-        overwrite_input_shapes=overwrite_input_shapes,
-        mutable_initializer=True,
+    model_opt = utils.optimize_with_onnxruntime(model_copy)
+    model_opt = utils.constant_folding(
+        model_opt,
+        overwrite_input_shapes=onnxsim.check_and_update_input_shapes(
+            model_opt, overwrite_input_shapes
+        ),
     )
+    model_opt = utils.optimize_with_onnxruntime(model_opt)
+    model_opt = utils.infer_onnx_tensor_shapes(model_opt)
 
-    try:
-        onnx.save(model_opt, output_model)
-    except ValueError:
-        # large models
-        onnx.save(
-            copy.deepcopy(model_opt),
-            output_model,
-            save_as_external_data=True,
-            all_tensors_to_one_file=True,
-            location=os.path.basename(output_model) + ".data",
-        )
+    utils.save_onnx(model_opt, output_model)
 
-    if check_ok:
-        print("Finish! Here is the difference:")
-        model_info.print_simplifying_info(model, model_opt)
-    else:
-        print(
-            'Check failed. Please be careful to use the simplified model, or try specifying "--skip-fuse-bn" or "--skip-optimization" (run "onnxsim -h" for details).'
-        )
-        print("Here is the difference after simplification:")
-        model_info.print_simplifying_info(model, model_opt)
-        sys.exit(1)
+    utils.check_opt_model(
+        model_opt, model_orig, n_times=5, input_shapes=overwrite_input_shapes
+    )
+    onnxsim.print_simplifying_info(model_orig, model_opt)
+    return model_opt
 
 
-def compile_onnx(input_model: Path, output_dfg: Path, output_dot: Path) -> None:
-    model = onnx.load_model(input_model)
-    try:
-        graph = compile(model.SerializeToString(), target_ir=TARGET_IR, dot_graph=output_dot, target_npu=TARGET_NPU)
-    except ValueError:
-        model = move_initializer_to_input(model)
-        graph = compile(model.SerializeToString(), target_ir=TARGET_IR, dot_graph=output_dot, target_npu=TARGET_NPU)
+def compile_onnx(
+    input_model: Union[Path, onnx.ModelProto], output_dfg: Path, output_dot: Path
+) -> None:
+    if isinstance(input_model, Path):
+        input_model = utils.load_onnx(input_model)
+
+    model = input_model
+
+    if model.ByteSize() >= onnx.checker.MAXIMUM_PROTOBUF:
+        # make every initializer graph_input, for compiler can't understand large(>2GB) onnx model.
+        model = utils.move_initializer_to_input(model)
+
+    graph = compile(
+        model.SerializeToString(),
+        target_ir=TARGET_IR,
+        dot_graph=output_dot,
+        target_npu=TARGET_NPU,
+    )
 
     with open(output_dfg, "wb") as f:
         f.write(bytes(graph))
-
-
-def optimize_with_onnxruntime(input_model: Path) -> onnx.ModelProto:
-    with tempfile.NamedTemporaryFile(suffix=".onnx") as file:
-        opt_onnx_path = file.name
-    sess_options = ort.SessionOptions()
-    # Set graph optimization level
-    sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_BASIC
-    # To enable model serialization after graph optimization
-    sess_options.optimized_model_filepath = opt_onnx_path
-    _ = ort.InferenceSession(input_model.as_posix(), sess_options, providers=["CPUExecutionProvider"])
-
-    try:
-        model = onnx.load_model(opt_onnx_path)
-    except FileNotFoundError:
-        model = onnx.load_model(opt_onnx_path, load_external_data=False)
-        load_external_data_for_model(model, input_model.parent)
-
-    return model
-
-
-def move_initializer_to_input(model: onnx.ModelProto) -> onnx.ModelProto:
-    # make every initializer graph_input, for compiler can't understand large(>2GB) onnx model.
-    grpah_inputs = []
-    for init in model.graph.initializer:
-        np_array = onnx.numpy_helper.to_array(init)
-        grpah_inputs.append(
-            onnx.helper.make_tensor_value_info(
-                init.name, onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[np_array.dtype], [*np_array.shape]
-            )
-        )
-    model.graph.input.extend(grpah_inputs)
-    model.graph.ClearField("initializer")
-    return model

--- a/optimum/litmus/__init__.py
+++ b/optimum/litmus/__init__.py
@@ -1,6 +1,6 @@
 import copy
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 import onnxoptimizer
 import onnxruntime as ort
@@ -11,7 +11,7 @@ from optimum.exporters.onnx import main_export
 from optimum.litmus import onnxsim, utils
 
 TARGET_IR = "dfg"
-TARGET_NPU = "warboy-b0"
+TARGET_NPU = "renegade"
 
 # set default onnxruntime looging level 3: Error to suppress warnings(2: Warning)
 ort.set_default_logger_severity(3)
@@ -50,7 +50,7 @@ def simplify_onnx(
 
 
 def compile_onnx(
-    input_model: Union[Path, onnx.ModelProto], output_dfg: Path, output_dot: Path
+    input_model: Union[Path, onnx.ModelProto], output_dfg: Path, output_dot: Optional[Path] = None
 ) -> None:
     if isinstance(input_model, Path):
         input_model = utils.load_onnx(input_model)

--- a/optimum/litmus/docs/README.md
+++ b/optimum/litmus/docs/README.md
@@ -1,0 +1,23 @@
+# Generation-step-wise ONNX graph gen
+## 용어
+- gen-step: "generation step" 의 줄임말로서, text generation 에서 한 단위의 토큰을 생성하는 각 단계를 의미한다. pre-fill phase 의 경우는 `gen-step=0` 이며, 이후 decode phase 의 경우는 `gen-step=1, 2, 3...` 이다. 참고로 `max(generation_step) = max_new_tokens` 이다. 
+  - max_new_tokens: https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationConfig.max_new_tokens
+  - generation step 이라는 표현은 huggingface 의 문서에 등장한다. https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.TFGenerationMixin.compute_transition_scores.scores 등.
+- decode_model_merged.onnx: huggingface 의 `text-generation-with-past` task 로 모델 export 를 하게되면 생성되는 출력 모델이다. 이 모델은 pre-fill phase 의 decode_model.onnx 와 decode phase 의 decode_model_with_past.onnx 를 sub-graph 형태로 병합한  그래프로 구성된다. 각 sub-graph 는 공통된 초기값을 가지므로 두 그래프를 병합함으로써 모델 바이너리 사이즈가 증가하지는 않는다. 또한, dynamic axis 를 사용하므로 variable input length 및 variable gen-step 의 text-generation 과정을 하나의 단일한 ONNX 모델로 표현 가능하다.
+- decoder_model-opt_gen_step={}.onnx
+  - opt: `Shape` 오퍼레이터를 포함하여 constant folding 가능한 모든 graph 패턴이 단순화되어 있다. 또한 ONNX opset_version=13 하에서 elimination 과 fusing 도 적용되어 있다. 마지막으로 모든 tensor 의 입출력 값이 fixed shape 으로 추론되어 있는 그래프를 의미한다.
+  - `gen_step={}` 은 각 generation step 을 의미한다. "gen-step" 항목의 설명 참조.
+
+## 동작 방식
+- huggingface `transformers` 와 `optimum` 을 베이스로 동작한다.
+  - `optimum` 에서는 pt -> onnx export 기능을, `transformers` 에서는 onnx export 대상이 되는 모델을 가져온다.
+- `optimum.litmus` 경로에는 onnx export, onnx simplification/optimization, compilation 관련 일반적인 기능이 구현되어 있다.
+- `optimum.litmus.nlp` 경로에는 task-specific 한 기능이 구현되어 있다. 예를 들어, text-generation task 의 경우 `simplify_text_generation_onnx` 함수에서 task-specific 한 모델 전처리를 거친 뒤 `optimum.litmus.simplify_onnx` 함수를 내부적으로 호출하여 onnx 모델 단순화를 수행하는 식이다.
+- "generation-step-wise ONNX graph generation": text-generation 은 pre-fill phase 뿐만 아니라 decode phase 를 포함하고 있기 때문에 단순 한 번의 추론으로 끝나지 않고, 동적으로 recursive 하게 다음 토큰을 생성하는 task 이다. 다시 말해 각 generation step 별로 입출력의 크기가 다르기 때문에 정적 tensor shape 을 추론하기 위하여는 각 step 별로 주어진 입력 크기에 따라 onnx graph 를 생성하는 방식으로 동작해야한다.
+
+## 모델
+아래 링크의 google drive "decoder_model-opt_gen_step={}.onnx" ONNX 파일
+- GPT2: https://furiosa-ai.atlassian.net/jira/software/c/projects/SWPROJ/boards/2/timeline?selectedIssue=SWPROJ-81
+- GPT-Neo: https://furiosa-ai.atlassian.net/jira/software/c/projects/SWPROJ/boards/2/timeline?selectedIssue=SWPROJ-80
+- LLaMA: https://furiosa-ai.atlassian.net/jira/software/c/projects/SWPROJ/boards/2/timeline?selectedIssue=SWPROJ-85
+- OPT: TBA

--- a/optimum/litmus/nlp/__init__.py
+++ b/optimum/litmus/nlp/__init__.py
@@ -1,3 +1,104 @@
+import copy
+from pathlib import Path
+from typing import Optional, Union
+
+import onnx
+from optimum.litmus import simplify_onnx, utils
+
 TASKS = ["text-generation-with-past"]
 BATCH_SIZE = 1
-SEQUENCE_LENGTH = 128
+INPUT_LENGTH = 8
+
+
+def simplify(
+    input_model: Union[Path, onnx.ModelProto],
+    output_dir: Path,
+    batch_size: int,
+    input_length: int,
+    generation_step: Optional[int] = None,
+    task: str = "text-generation-with-past",
+) -> onnx.ModelProto:
+    if task != "text-generation-with-past":
+        raise Exception("Unsupported model task: {task}")
+    model_opt = simplify_text_generation_onnx(
+        input_model, output_dir, batch_size, input_length, generation_step
+    )
+    return model_opt
+
+
+def simplify_text_generation_onnx(
+    input_model: Union[Path, onnx.ModelProto],
+    output_dir: Path,
+    batch_size: int,
+    input_len: int,
+    gen_step: int,
+) -> onnx.ModelProto:
+    onnx_model = utils.load_onnx(input_model) if isinstance(input_model, Path) else input_model
+    decoder_model = separate_merged_graph(copy.deepcopy(onnx_model), gen_step)
+
+    overwrite_input_shapes = {
+        "input_ids": [batch_size, input_len],
+        "attention_mask": [batch_size, input_len],
+    }
+    if gen_step > 0:
+        overwrite_input_shapes = {"input_ids": [batch_size, 1], "attention_mask": [batch_size, 1]}
+        for vi in onnx_model.graph.input:
+            if "past_key_values" not in vi.name:
+                continue
+            utils.make_dynamic_axis_fixed(vi, "batch_size", batch_size)
+            utils.make_dynamic_axis_fixed(vi, "past_sequence_length", input_len + gen_step)
+            if utils.has_dynamic_axis(vi):
+                raise Exception(
+                    f"ModelProto has dim_param in graph.input. Dynamic axis should be fixed: {vi}"
+                )
+            overwrite_input_shapes.update(
+                {vi.name: [dim.dim_value for dim in vi.type.tensor_type.shape.dim]}
+            )
+
+    output_model = output_dir / f"decoder_model-opt_gen_step={gen_step}.onnx"
+    model_opt = simplify_onnx(decoder_model, output_model, overwrite_input_shapes)
+    return model_opt
+
+
+def separate_merged_graph(merged_model: onnx.ModelProto, gen_step: int) -> onnx.ModelProto:
+    subgraphs = utils.get_subgraphs(merged_model)
+    if not subgraphs:
+        raise Exception("ModelProto does not have subgraph(s).")
+    if len(subgraphs) > 2:
+        raise Exception("ModelProto has more than 2 subgraphs, which is out of scope.")
+
+    model_initializers = {init.name: init for init in merged_model.graph.initializer}
+
+    subgraph_inputs = [
+        vi
+        for vi in merged_model.graph.input
+        if any(vi.name == vi_name for vi_name in ["input_ids", "attention_mask"])
+    ]
+    if gen_step == 0:
+        subgraph_nodes = subgraphs[0].node
+        subgraph_outputs = subgraphs[0].output
+    if gen_step > 0:
+        subgraph_inputs.extend(
+            [vi for vi in merged_model.graph.input if "past_key_values" in vi.name]
+        )
+        subgraph_nodes = subgraphs[1].node
+        subgraph_outputs = subgraphs[1].output
+
+    subgraph_initializers = []
+    for node in subgraph_nodes:
+        for node_input in node.input:
+            if node_input in model_initializers:
+                if model_initializers[node_input] in subgraph_initializers:
+                    continue
+                subgraph_initializers.append(model_initializers[node_input])
+
+    separated_model = utils.make_onnx_model(
+        inputs=subgraph_inputs,
+        nodes=subgraph_nodes,
+        initializers=subgraph_initializers,
+        outputs=subgraph_outputs,
+        opset_imports=merged_model.opset_import,
+        graph_name=f"gen_step={gen_step}",
+        producer_name=merged_model.producer_name,
+    )
+    return separated_model

--- a/optimum/litmus/nlp/gpt-neo.py
+++ b/optimum/litmus/nlp/gpt-neo.py
@@ -1,35 +1,70 @@
 import argparse
 from pathlib import Path
 
-from optimum.litmus import compile_onnx, export_onnx, simplify_onnx
-from optimum.litmus.nlp import BATCH_SIZE, SEQUENCE_LENGTH, TASKS
+from optimum.litmus import compile_onnx, export_onnx, utils
+from optimum.litmus.nlp import BATCH_SIZE, INPUT_LENGTH, TASKS, simplify
 
 
 def main():
     parser = argparse.ArgumentParser("FuriosaAI litmus GPT Neo using HF Optimum API.")
-    parser.add_argument("output_dir", help="path to directory to save outputs")
-    parser.add_argument("--size", "-s", choices=["125m", "1.3b", "2.7b"], help="available model sizes")
+    parser.add_argument("output_dir", type=Path, help="path to directory to save outputs")
+    parser.add_argument(
+        "--model-size", "-s", choices=["125m", "1.3b", "2.7b"], help="available model sizes"
+    )
+    parser.add_argument(
+        "--batch-size",
+        "-b",
+        default=BATCH_SIZE,
+        type=utils.check_non_negative,
+        help="Batch size for model inputs",
+    )
+    parser.add_argument(
+        "--input-len",
+        default=INPUT_LENGTH,
+        type=utils.check_non_negative,
+        help="Length of input prommpt",
+    )
+    parser.add_argument(
+        "--gen-step",
+        default=0,
+        type=utils.check_non_negative,
+        help="Generation step to simplify onnx graph",
+    )
+    parser.add_argument(
+        "--task",
+        default="text-generation-with-past",
+        type=str,
+        choices=TASKS,
+        help="Task to export model for",
+    )
     args = parser.parse_args()
 
-    model_name = f"gpt-neo-{args.size}"
+    model_name = f"gpt-neo-{args.model_size}"
     model_tag = f"EleutherAI/{model_name}"
-    task = "text-generation-with-past"
-    assert task in TASKS
-    output = Path(args.output_dir)
-    if not output.exists():
-        output.mkdir(parents=True)
-    export_onnx(model_name_or_path=model_tag, output=output, task=task, framework="pt")
+    output_dir = args.output_dir
 
-    onnx_model_name = "decoder_model"
-    input_model = output / f"{onnx_model_name}.onnx"
-    opt_model = output / f"{onnx_model_name}-opt.onnx"
-    overwrite_input_shapes = {
-        "input_ids": [BATCH_SIZE, SEQUENCE_LENGTH],
-        "attention_mask": [BATCH_SIZE, SEQUENCE_LENGTH],
-    }
-    simplify_onnx(input_model, opt_model, overwrite_input_shapes)
+    if not output_dir.exists():
+        output_dir.mkdir(parents=True)
 
-    compile_onnx(opt_model, output / f"{model_name}.dfg", output / f"{model_name}.dot")
+    if not (output_dir / "decoder_model_merged.onnx").exists():
+        print("Exporting ONNX Model...")
+        export_onnx(model_name_or_path=model_tag, output=output_dir, task=args.task, framework="pt")
+
+    print("Simplifying ONNX Model...")
+    simplify(
+        output_dir / "decoder_model_merged.onnx",
+        output_dir,
+        args.batch_size,
+        args.input_len,
+        args.gen_step,
+        args.task,
+    )
+
+    compile_onnx(
+        output_dir / f"decoder_model-opt_gen_step={args.gen_step}.onnx",
+        output_dir / f"decoder_model-opt_gen_step={args.gen_step}.dfg",
+        output_dir / f"decoder_model-opt_gen_step={args.gen_step}.dot",
+    )
 
 
 if __name__ == "__main__":

--- a/optimum/litmus/nlp/gpt2.py
+++ b/optimum/litmus/nlp/gpt2.py
@@ -1,46 +1,78 @@
 import argparse
 from pathlib import Path
 
-from optimum.litmus import compile_onnx, export_onnx, simplify_onnx
-from optimum.litmus.nlp import BATCH_SIZE, SEQUENCE_LENGTH, TASKS
+from optimum.litmus import compile_onnx, export_onnx, utils
+from optimum.litmus.nlp import BATCH_SIZE, INPUT_LENGTH, TASKS, simplify
 
 
 def main():
     parser = argparse.ArgumentParser("FuriosaAI litmus GPT2 using HF Optimum API.")
-    parser.add_argument("output_dir", help="path to directory to save outputs")
-    parser.add_argument("--size", "-s", choices=["s", "m", "l", "xl"], help="available model sizes")
+    parser.add_argument("output_dir", type=Path, help="path to directory to save outputs")
+    parser.add_argument(
+        "--model-size", "-s", choices=["s", "m", "l", "xl"], help="available model sizes"
+    )
+    parser.add_argument(
+        "--batch-size",
+        "-b",
+        default=BATCH_SIZE,
+        type=utils.check_non_negative,
+        help="Batch size for model inputs",
+    )
+    parser.add_argument(
+        "--input-len",
+        default=INPUT_LENGTH,
+        type=utils.check_non_negative,
+        help="Length of input prommpt",
+    )
+    parser.add_argument(
+        "--gen-step",
+        default=0,
+        type=utils.check_non_negative,
+        help="Generation step to simplify onnx graph",
+    )
+    parser.add_argument(
+        "--task",
+        default="text-generation-with-past",
+        type=str,
+        choices=TASKS,
+        help="Task to export model for",
+    )
     args = parser.parse_args()
 
-    if args.size == "s":
+    if args.model_size == "s":
         model_name = "gpt2"
-    if args.size == "m":
+    if args.model_size == "m":
         model_name = "gpt2-medium"
-    if args.size == "l":
+    if args.model_size == "l":
         model_name = "gpt2-large"
-    if args.size == "xl":
+    if args.model_size == "xl":
         model_name = "gpt2-xl"
     model_tag = model_name
-    task = "text-generation-with-past"
-    assert task in TASKS
-    output = Path(args.output_dir)
-    if not output.exists():
-        output.mkdir(parents=True)
-    export_onnx(model_name_or_path=model_tag, output=output, task=task, framework="pt")
+    output_dir = args.output_dir
 
-    onnx_model_name = "decoder_model"
-    input_model = output / f"{onnx_model_name}.onnx"
-    opt_model = output / f"{onnx_model_name}-opt.onnx"
-    overwrite_input_shapes = {
-        "input_ids": [BATCH_SIZE, SEQUENCE_LENGTH],
-        "attention_mask": [BATCH_SIZE, SEQUENCE_LENGTH],
-    }
-    simplify_onnx(input_model, opt_model, overwrite_input_shapes)
+    if not output_dir.exists():
+        output_dir.mkdir(parents=True)
 
-    compile_onnx(opt_model, output / f"{model_name}.dfg", output / f"{model_name}.dot")
+    if not (output_dir / "decoder_model_merged.onnx").exists():
+        print("Exporting ONNX Model...")
+        export_onnx(model_name_or_path=model_tag, output=output_dir, task=args.task, framework="pt")
+
+    print("Simplifying ONNX Model...")
+    simplify(
+        output_dir / "decoder_model_merged.onnx",
+        output_dir,
+        args.batch_size,
+        args.input_len,
+        args.gen_step,
+        args.task,
+    )
+
+    compile_onnx(
+        output_dir / f"decoder_model-opt_gen_step={args.gen_step}.onnx",
+        output_dir / f"decoder_model-opt_gen_step={args.gen_step}.dfg",
+        output_dir / f"decoder_model-opt_gen_step={args.gen_step}.dot",
+    )
 
 
 if __name__ == "__main__":
-    import os
-
-    os.environ["ONNXSIM_FIXED_POINT_ITERS"] = "200"
     main()

--- a/optimum/litmus/nlp/llama.py
+++ b/optimum/litmus/nlp/llama.py
@@ -1,35 +1,76 @@
 import argparse
 from pathlib import Path
 
-from optimum.litmus import compile_onnx, export_onnx, simplify_onnx
-from optimum.litmus.nlp import BATCH_SIZE, SEQUENCE_LENGTH, TASKS
+from optimum.litmus import compile_onnx, export_onnx, utils
+from optimum.litmus.nlp import BATCH_SIZE, INPUT_LENGTH, TASKS, simplify
 
 
 def main():
     parser = argparse.ArgumentParser("FuriosaAI litmus LLaMA using HF Optimum API.")
-    parser.add_argument("output_dir", help="path to directory to save outputs")
-    parser.add_argument("--size", "-s", choices=["7b", "13b", "30b", "65b"], help="available model sizes")
+    parser.add_argument("output_dir", type=Path, help="path to directory to save outputs")
+    parser.add_argument(
+        "--model-size", "-s", choices=["7b", "13b", "30b", "65b"], help="available model sizes"
+    )
+    parser.add_argument(
+        "--batch-size",
+        "-b",
+        default=BATCH_SIZE,
+        type=utils.check_non_negative,
+        help="Batch size for model inputs",
+    )
+    parser.add_argument(
+        "--input-len",
+        default=INPUT_LENGTH,
+        type=utils.check_non_negative,
+        help="Length of input prommpt",
+    )
+    parser.add_argument(
+        "--gen-step",
+        default=0,
+        type=utils.check_non_negative,
+        help="Generation step to simplify onnx graph",
+    )
+    parser.add_argument(
+        "--task",
+        default="text-generation-with-past",
+        type=str,
+        choices=TASKS,
+        help="Task to export model for",
+    )
     args = parser.parse_args()
 
-    model_name = f"llama-{args.size}"
+    model_name = f"llama-{args.model_size}"
     model_tag = f"decapoda-research/{model_name}-hf"
-    task = "text-generation-with-past"
-    assert task in TASKS
-    output = Path(args.output_dir)
-    if not output.exists():
-        output.mkdir(parents=True)
-    export_onnx(model_name_or_path=model_tag, output=output, task=task, framework="pt")
+    output_dir = args.output_dir
 
-    onnx_model_name = "decoder_model"
-    input_model = output / f"{onnx_model_name}.onnx"
-    opt_model = output / f"{onnx_model_name}-opt.onnx"
-    overwrite_input_shapes = {
-        "input_ids": [BATCH_SIZE, SEQUENCE_LENGTH],
-        "attention_mask": [BATCH_SIZE, SEQUENCE_LENGTH],
-    }
-    simplify_onnx(input_model, opt_model, overwrite_input_shapes)
+    if not output_dir.exists():
+        output_dir.mkdir(parents=True)
 
-    compile_onnx(opt_model, output / f"{model_name}.dfg", output / f"{model_name}.dot")
+    if not (output_dir / "decoder_model_merged.onnx").exists():
+        print("Exporting ONNX Model...")
+        export_onnx(
+            model_name_or_path=model_tag,
+            output=output_dir,
+            task=args.task,
+            framework="pt",
+            do_validation=False,
+        )
+
+    print("Simplifying ONNX Model...")
+    simplify(
+        output_dir / "decoder_model_merged.onnx",
+        output_dir,
+        args.batch_size,
+        args.input_len,
+        args.gen_step,
+        args.task,
+    )
+
+    compile_onnx(
+        output_dir / f"decoder_model-opt_gen_step={args.gen_step}.onnx",
+        output_dir / f"decoder_model-opt_gen_step={args.gen_step}.dfg",
+        output_dir / f"decoder_model-opt_gen_step={args.gen_step}.dot",
+    )
 
 
 if __name__ == "__main__":

--- a/optimum/litmus/onnxsim.py
+++ b/optimum/litmus/onnxsim.py
@@ -1,17 +1,11 @@
 # https://github.com/daquexian/onnx-simplifier/blob/v0.3.10/onnxsim/onnx_simplifier.py
-import argparse
-from collections import OrderedDict
 import copy
-import os
-import sys
-from typing import Callable, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np  # type: ignore
 import onnx.helper  # type: ignore
 import onnx.numpy_helper  # type: ignore
 import onnx.shape_inference  # type: ignore
-import onnxoptimizer  # type: ignore
-import onnxruntime as rt  # type: ignore
 
 import onnx  # type: ignore
 

--- a/optimum/litmus/onnxsim.py
+++ b/optimum/litmus/onnxsim.py
@@ -1,0 +1,442 @@
+# https://github.com/daquexian/onnx-simplifier/blob/v0.3.10/onnxsim/onnx_simplifier.py
+import argparse
+from collections import OrderedDict
+import copy
+import os
+import sys
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
+
+import numpy as np  # type: ignore
+import onnx.helper  # type: ignore
+import onnx.numpy_helper  # type: ignore
+import onnx.shape_inference  # type: ignore
+import onnxoptimizer  # type: ignore
+import onnxruntime as rt  # type: ignore
+
+import onnx  # type: ignore
+
+Tensors = Dict[str, np.ndarray]
+TensorShape = List[int]
+TensorShapes = Dict[str, TensorShape]
+TensorShapesWithOptionalKey = Dict[Optional[str], TensorShape]
+
+
+def has_subgraph_in_node(node: onnx.NodeProto):
+    for attr in node.attribute:
+        if attr.type in [onnx.AttributeProto.GRAPH, onnx.AttributeProto.GRAPHS]:
+            return True
+    return False
+
+
+def get_all_subgraphs(model: onnx.ModelProto):
+    graphs = [model.graph]
+    for node in model.graph.node:
+        if has_subgraph_in_node(node):
+            for attr in node.attribute:
+                graphs.append(attr.g)
+    return graphs
+
+
+def add_features_to_output(m: onnx.ModelProto, nodes: Sequence[onnx.NodeProto]) -> None:
+    """
+    Add features to output in pb, so that ONNX Runtime will output them.
+    Note: the resulting model is not valid, because
+    outputs of main graph should has other fields such as 'type'
+    :param m: the model that will be run in ONNX Runtime
+    :param nodes: nodes whose outputs will be added into the graph outputs
+    """
+    for node in nodes:
+        for output in node.output:
+            m.graph.output.extend([onnx.ValueInfoProto(name=output)])
+
+
+def get_shape_from_value_info_proto(v: onnx.ValueInfoProto) -> List[int]:
+    return [dim.dim_value for dim in v.type.tensor_type.shape.dim]
+
+
+def get_value_info_all(m: onnx.ModelProto, name: str) -> Optional[onnx.ValueInfoProto]:
+    for v in m.graph.value_info:
+        if v.name == name:
+            return v
+
+    for v in m.graph.input:
+        if v.name == name:
+            return v
+
+    for v in m.graph.output:
+        if v.name == name:
+            return v
+
+    return None
+
+
+def get_shape(m: onnx.ModelProto, name: str) -> TensorShape:
+    """
+    Note: This method relies on onnx shape inference, which is not reliable. So only use it on input or output tensors
+    """
+    v = get_value_info_all(m, name)
+    if v is not None:
+        return get_shape_from_value_info_proto(v)
+    raise RuntimeError('Cannot get shape of "{}"'.format(name))
+
+
+def get_elem_type(m: onnx.ModelProto, name: str) -> int:
+    v = get_value_info_all(m, name)
+    if v is not None:
+        return v.type.tensor_type.elem_type
+    raise RuntimeError('Cannot get shape dtype "{}"'.format(name))
+
+
+def get_np_type_from_elem_type(elem_type: int):
+    sizes = (
+        None,
+        np.float32,
+        np.uint8,
+        np.int8,
+        np.uint16,
+        np.int16,
+        np.int32,
+        np.int64,
+        str,
+        bool,
+        np.float16,
+        np.double,
+        np.uint32,
+        np.uint64,
+        np.complex64,
+        np.complex128,
+        np.float16,
+    )
+    assert len(sizes) == 17
+    size = sizes[elem_type]
+    assert size is not None
+    return size
+
+
+def get_inputs(model: onnx.ModelProto) -> List[onnx.ValueInfoProto]:
+    initializer_names = [x.name for x in model.graph.initializer]
+    return [ipt for ipt in model.graph.input if ipt.name not in initializer_names]
+
+
+def get_input_names(model: onnx.ModelProto) -> List[str]:
+    input_names = [ipt.name for ipt in get_inputs(model)]
+    return input_names
+
+
+def generate_specific_rand_input(
+    model, input_shapes: TensorShapes, dynamic_input_shape: bool = False
+):
+    """
+    Only generate rand inputs whose shape in `input_shapes`
+    """
+
+    for key, shape in input_shapes.items():
+        shape_np = np.array(shape)
+        if not np.all(shape_np > 0):
+            # treat batch size as 1 automatically if dynamic_input_shape is True
+            if (
+                dynamic_input_shape and len(shape_np) >= 3 and np.all(shape_np[1:] > 0)
+            ):  # fixed, not using config
+                input_shapes[key] = [1] + shape[1:]
+                continue
+
+            raise RuntimeError(
+                'The shape of input "{}" has dynamic size "{}", '
+                'please try "--dynamic-input-shape" or determine '
+                'the input size manually by "--input-shape xxx". '
+                'Run "python3 -m onnxsim -h" for details'.format(key, shape)
+            )
+
+    inputs = {
+        ipt: np.array(
+            np.random.rand(*input_shapes[ipt]),
+            dtype=get_np_type_from_elem_type(get_elem_type(model, ipt)),
+        )
+        for ipt in input_shapes
+    }
+    return inputs
+
+
+def generate_all_rand_input(model, input_shapes: Optional[TensorShapes] = None):
+    """
+    Generate random array for all inputs of a model
+    """
+    if input_shapes is None:
+        input_shapes = {}
+    input_names = get_input_names(model)
+    full_input_shapes = {ipt: get_shape(model, ipt) for ipt in input_names}
+    assert None not in input_shapes
+    full_input_shapes.update(input_shapes)  # type: ignore
+    return generate_specific_rand_input(model, full_input_shapes)
+
+
+def is_non_deterministic_node(node: onnx.NodeProto) -> bool:
+    # TODO: handle node with subgraph
+    return node.op_type in [
+        "RandomNormal",
+        "RandomNormalLike",
+        "RandomUniform",
+        "RandomUniformLike",
+    ]
+
+
+def is_non_deterministic_model(model: onnx.ModelProto) -> bool:
+    return any([is_non_deterministic_node(node) for node in model.graph.node])
+
+
+def get_constant_nodes(
+    m: onnx.ModelProto, dynamic_input_shape: bool = False, include_subgraph: bool = False
+) -> List[onnx.NodeProto]:
+    const_nodes = []
+    const_tensors = [x.name for x in m.graph.initializer]
+    const_tensors.extend([node.output[0] for node in m.graph.node if node.op_type == "Constant"])
+
+    # The output shape of some node types is determined by the input value
+    # we consider the output of this node doesn't have constant shape,
+    # so we do not simplify a such node even if the node is Shape op
+    dynamic_tensors = []
+    if dynamic_input_shape:
+        dynamic_tensors.extend(get_input_names(m))
+
+    def is_dynamic(node):
+        if (
+            node.op_type in ["NonMaxSuppression", "NonZero", "Unique"]
+            and node.input[0] not in const_tensors
+        ):
+            return True
+        if (
+            node.op_type in ["Reshape", "Expand", "Upsample", "ConstantOfShape"]
+            and len(node.input) > 1
+            and node.input[1] not in const_tensors
+        ):
+            return True
+        if node.op_type in ["Resize"] and (
+            (len(node.input) > 2 and node.input[2] not in const_tensors)
+            or (len(node.input) > 3 and node.input[3] not in const_tensors)
+        ):
+            return True
+        return False
+
+    def check_node(graph):
+        for node in graph.node:
+            if has_subgraph_in_node(node):
+                # Skip this node if this node has subgraph in it
+                # "If" node with const cond will be eliminated by onnxoptimizer
+                if any(x in dynamic_tensors for x in node.input):
+                    dynamic_tensors.extend(node.output)
+                if include_subgraph:  # fixed not using config
+                    for attr in node.attribute:
+                        if attr.type in [onnx.AttributeProto.GRAPH, onnx.AttributeProto.GRAPHS]:
+                            check_node(attr.g)
+            elif any(x in dynamic_tensors for x in node.input):
+                dynamic_tensors.extend(node.output)
+            # Note "elif" here, only Shape op with non-dynamic input will be seen as const node
+            elif node.op_type == "Shape":
+                const_nodes.append(node)
+                const_tensors.extend(node.output)
+            elif is_dynamic(node):
+                dynamic_tensors.extend(node.output)
+            elif node.op_type in ["DequantizeLinear", "QuantizeLinear"]:
+                # Skip QuantizeLinear and DequantizeLinear to preserve quantization info
+                pass
+            elif all([x in const_tensors for x in node.input]) and not is_non_deterministic_node(
+                node
+            ):
+                # Skip these nodes to avoid bloating the model size
+                if node.op_type in ["Tile"]:
+                    continue
+                const_nodes.append(node)
+                const_tensors.extend(node.output)
+
+    check_node(m.graph)
+    return copy.deepcopy(const_nodes)
+
+
+def eliminate_const_nodes(
+    model: onnx.ModelProto, const_nodes: Sequence[onnx.NodeProto], res: Tensors
+) -> onnx.ModelProto:
+    """
+    :param model: the original onnx model
+    :param const_nodes: const nodes detected by `get_constant_nodes`
+    :param res: The dict containing all tensors, got by `forward_all`
+    :return: the simplified onnx model. Redundant ops are all removed.
+    """
+
+    def recursive_eliminate_const_nodes_in_graph(graph, const_nodes, res):
+        new_nodes = []
+        for i, node in enumerate(graph.node):
+            if node in const_nodes:
+                for output in node.output:
+                    new_node = copy.deepcopy(node)
+                    new_node.name = "node_" + output
+                    new_node.op_type = "Constant"
+                    new_attr = onnx.helper.make_attribute(
+                        "value", onnx.numpy_helper.from_array(res[output], name=output)
+                    )
+                    del new_node.input[:]
+                    del new_node.attribute[:]
+                    del new_node.output[:]
+                    new_node.output.extend([output])
+                    new_node.attribute.extend([new_attr])
+                    new_nodes.append(new_node)
+            else:
+                new_nodes.append(node)
+                if has_subgraph_in_node(node):
+                    for attr in node.attribute:
+                        if attr.g is None:
+                            continue
+                        recursive_eliminate_const_nodes_in_graph(attr.g, const_nodes, res)
+        del graph.node[:]
+        graph.node.extend(new_nodes)
+
+    recursive_eliminate_const_nodes_in_graph(model.graph, const_nodes, res)
+
+    return model
+
+
+def clean_constant_nodes(const_nodes: Sequence[onnx.NodeProto], res: Tensors):
+    """
+    It seems not needed since commit 6f2a72, but maybe it still prevents some unknown bug
+    :param const_nodes: const nodes detected by `get_constant_nodes`
+    :param res: The dict containing all tensors, got by `forward_all`
+    :return: The constant nodes which have an output in res
+    """
+    return [node for node in const_nodes if node.output[0] in res]
+
+
+def check_and_update_input_shapes(
+    model: onnx.ModelProto,
+    input_shapes: TensorShapesWithOptionalKey,
+    dynamic_input_shape: bool = False,
+) -> TensorShapes:
+    input_names = get_input_names(model)
+    if None in input_shapes:
+        if len(input_names) == 1:
+            input_shapes[input_names[0]] = input_shapes[None]
+            del input_shapes[None]
+        else:
+            raise RuntimeError(
+                'The model has more than 1 inputs, please use the format "input_name:dim0,dim1,...,dimN" in --input-shape'
+            )
+    for x in input_shapes:
+        if x not in input_names:
+            raise RuntimeError('The model doesn\'t have input named "{}"'.format(x))
+
+    # Overwrite model input shape
+    if not dynamic_input_shape:
+        for name, input_shape in input_shapes.items():
+            for ipt in model.graph.input:
+                if ipt.name == name:
+                    for i, dim in enumerate(ipt.type.tensor_type.shape.dim):
+                        dim.dim_value = input_shape[i]
+
+    return input_shapes  # type: ignore
+
+
+# https://github.com/daquexian/onnx-simplifier/blob/v0.4.33/onnxsim/model_info.py
+from collections import defaultdict
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from rich import print
+from rich.table import Table
+from rich.text import Text
+
+import onnx
+
+__all__ = ["ModelInfo", "print_simplifying_info"]
+
+
+def human_readable_size(num, suffix="B"):
+    for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]:
+        if abs(num) < 1024.0:
+            return f"{num:3.1f}{unit}{suffix}"
+        num /= 1024.0
+    return f"{num:.1f}Yi{suffix}"
+
+
+class ModelInfo:
+    """
+    Model info contains:
+    1. Num of every op
+    2. Model size
+    TODO:
+    Based on onnx runtime, get
+    1、FLOPs
+    2、forward memory footprint
+    3、memory access
+    4、compute density
+    """
+
+    def get_info(self, graph: onnx.GraphProto) -> Tuple[Dict[str, int], int]:
+        op_nums = defaultdict(int)
+        model_size = 0
+        for node in graph.node:
+            op_nums[node.op_type] += 1
+            for attr in node.attribute:
+                sub_graphs = []
+                if attr.g is not None:
+                    sub_graphs.append(attr.g)
+                if attr.graphs is not None:
+                    sub_graphs.extend(attr.graphs)
+                for sub_graph in sub_graphs:
+                    sub_op_nums, sub_model_size = self.get_info(sub_graph)
+                    op_nums = defaultdict(
+                        int,
+                        {k: op_nums[k] + sub_op_nums[k] for k in set(op_nums) | set(sub_op_nums)},
+                    )
+                    model_size += sub_model_size
+        op_nums["Constant"] += len(graph.initializer)
+        model_size += graph.ByteSize()
+        return op_nums, model_size
+
+    def __init__(self, model: onnx.ModelProto):
+        self.op_nums, self.model_size = self.get_info(model.graph)
+
+
+def print_simplifying_info(model_ori: onnx.ModelProto, model_opt: onnx.ModelProto) -> None:
+    """
+    --------------------------------------------------------
+    |             | original model | simplified model |
+    --------------------------------------------------------
+    | ****        | ****           | ****             |
+    --------------------------------------------------------
+    | Model Size  | ****           | ****             |
+    --------------------------------------------------------
+    """
+    ori_info = ModelInfo(model_ori)
+    opt_info = ModelInfo(model_opt)
+    table = Table()
+    table.add_column("")
+    table.add_column("Original Model")
+    table.add_column("Simplified Model")
+
+    def add_row(
+        table: Table,
+        key,
+        ori_data,
+        opt_data,
+        is_better: Callable[[Any, Any], Any],
+        postprocess: Optional[Callable[[Any], Any]] = None,
+    ) -> None:
+        if postprocess is None:
+            postprocess = str
+        if is_better(opt_data, ori_data):
+            table.add_row(
+                key, postprocess(ori_data), Text(postprocess(opt_data), style="bold green1")
+            )
+        else:
+            table.add_row(key, postprocess(ori_data), postprocess(opt_data))
+
+    for key in sorted(list(set(ori_info.op_nums.keys()) | set(opt_info.op_nums.keys()))):
+        add_row(
+            table, key, ori_info.op_nums[key], opt_info.op_nums[key], lambda opt, ori: opt < ori
+        )
+    add_row(
+        table,
+        "Model Size",
+        ori_info.model_size,
+        opt_info.model_size,
+        lambda opt, ori: opt < ori,
+        postprocess=human_readable_size,
+    )
+    print(table)

--- a/optimum/litmus/utils.py
+++ b/optimum/litmus/utils.py
@@ -134,6 +134,10 @@ def save_onnx(model: onnx.ModelProto, output_model: Union[Path, str]) -> None:
     if model.ByteSize() < onnx.checker.MAXIMUM_PROTOBUF:
         onnx.save(model, output_model.as_posix())
     else:
+        external_data_path = output_model.parent / (output_model.name + "_data")
+        if external_data_path.exists():
+            external_data_path.unlink()
+
         # large models
         onnx.save(
             model,

--- a/optimum/litmus/utils.py
+++ b/optimum/litmus/utils.py
@@ -1,0 +1,307 @@
+import argparse
+from collections import OrderedDict
+import copy
+import os
+from pathlib import Path
+import sys
+import tempfile
+from typing import Dict, List, Optional, Sequence, Union
+
+import numpy as np
+import onnxruntime as ort
+
+import onnx
+from optimum.litmus import onnxsim
+
+
+def constant_folding(
+    model: onnx.ModelProto, overwrite_input_shapes: Dict[str, List[int]]
+) -> onnx.ModelProto:
+    const_nodes = onnxsim.get_constant_nodes(model, dynamic_input_shape=False)
+    res = forward_onnx_for_node_outputs(
+        model, const_nodes, input_shapes=overwrite_input_shapes, input_data={}, custom_lib=None
+    )
+    const_nodes = onnxsim.clean_constant_nodes(const_nodes, res)
+    model = onnxsim.eliminate_const_nodes(model, const_nodes, res)
+    check_onnx(model)
+    return model
+
+
+def forward_onnx_for_node_outputs(
+    model: onnx.ModelProto,
+    nodes: Sequence[onnx.NodeProto],
+    input_shapes: Optional[onnxsim.TensorShapes] = None,
+    input_data: Optional[onnxsim.Tensors] = None,
+    custom_lib: Optional[str] = None,
+    include_subgraph: bool = False,
+) -> onnxsim.Tensors:
+    if input_shapes is None:
+        input_shapes = {}
+    model = copy.deepcopy(model)
+
+    onnxsim.add_features_to_output(model, nodes)
+    output_names = []
+    for node in nodes:
+        output_names.extend(node.output)
+
+    if include_subgraph:  # fixed: not using config
+        subgraphs = onnxsim.get_all_subgraphs(model)
+        for i in range(1, len(subgraphs)):
+            subgraphs[0].node.extend(subgraphs[i].node)
+        model = onnx.utils.Extractor(model).extract_model([], output_names)
+        check_onnx(model)
+    res = forward_onnx(
+        model,
+        input_data=input_data,
+        input_shapes=input_shapes,
+        outputs=output_names,
+        custom_lib=custom_lib,
+    )
+    return res
+
+
+# https://github.com/daquexian/onnx-simplifier/blob/v0.4.33/onnxsim/model_checking.py#L15-L185
+def check_opt_model(
+    model_opt: Union[str, onnx.ModelProto],
+    model_ori: Union[str, onnx.ModelProto],
+    n_times: int = 5,
+    input_shapes: Optional[onnxsim.TensorShapes] = None,
+    input_data: Optional[onnxsim.Tensors] = None,
+    custom_lib: Optional[str] = None,
+    verbose=True,
+) -> bool:
+    """
+    :param model_opt: The simplified ONNX model
+    :param model_ori: The original ONNX model
+    :param n_times: Generate n random inputs
+    :param input_shapes: Shapes of generated random inputs
+    :param input_data: User-given data instead of random generated data
+    :param custom_lib: ONNX Runtime custom lib for custom ops
+    """
+
+    if input_shapes is None:
+        input_shapes = {}
+
+    check_onnx(model_opt)
+
+    sess_options = ort.SessionOptions()
+    sess_options.graph_optimization_level = ort.GraphOptimizationLevel(0)
+    sess_options.log_severity_level = 3
+    sess_opt = initiate_onnxruntime_session(model_opt, sess_options)
+    sess_ori = initiate_onnxruntime_session(model_ori, sess_options)
+
+    assert not [
+        node for node in model_opt.graph.node if node.op_type == "Shape"
+    ], "Shape operator remains in simplified ONNX graph. It should be further simplified."
+
+    for i in range(n_times):
+        print(f"Checking {i+1}/{n_times}...")
+        if input_data is None:
+            inputs = onnxsim.generate_all_rand_input(model_opt, input_shapes=input_shapes)
+        else:
+            inputs = input_data
+        res_ori = forward_onnx(model_ori, inputs, custom_lib, sess=sess_opt)
+        res_opt = forward_onnx(model_opt, inputs, custom_lib, sess=sess_ori)
+
+        for name in res_opt.keys():
+            if not np.allclose(res_opt[name], res_ori[name], rtol=1e-4, atol=1e-5):
+                if verbose:
+                    print(
+                        "Tensor {} changes after optimization. The max diff is {}.".format(
+                            name, np.max(np.abs(res_opt[name] - res_ori[name]))
+                        )
+                    )
+                    print("After optimization:")
+                    print(res_opt[name])
+                    print("Before optimization:")
+                    print(res_ori[name])
+                    print("----------------")
+                return False
+    return True
+
+
+def load_onnx(input_model: Union[Path, str]) -> onnx.ModelProto:
+    input_model = Path(input_model) if isinstance(input_model, str) else input_model
+    onnx_model = onnx.load_model(input_model.as_posix())
+    return onnx_model
+
+
+def save_onnx(model: onnx.ModelProto, output_model: Union[Path, str]) -> None:
+    model = copy.deepcopy(model)
+    if isinstance(output_model, str):
+        output_model = Path(output_model)
+
+    if model.ByteSize() < onnx.checker.MAXIMUM_PROTOBUF:
+        onnx.save(model, output_model.as_posix())
+    else:
+        # large models
+        onnx.save(
+            model,
+            output_model.as_posix(),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=os.path.basename(output_model) + "_data",
+        )
+
+
+def infer_onnx_tensor_shapes(model: onnx.ModelProto) -> onnx.ModelProto:
+    if model.ByteSize() < onnx.checker.MAXIMUM_PROTOBUF:
+        model = onnx.shape_inference.infer_shapes(model)
+    else:
+        with tempfile.NamedTemporaryFile(suffix=".onnx") as file:
+            inferred_model_path = file.name
+        save_onnx(model, inferred_model_path)
+        onnx.shape_inference.infer_shapes_path(inferred_model_path)
+        model = load_onnx(inferred_model_path)
+    return model
+
+
+def make_onnx_model(
+    inputs: List[onnx.ValueInfoProto],
+    nodes: List[onnx.NodeProto],
+    initializers: List[onnx.TensorProto],
+    outputs: List[onnx.ValueInfoProto],
+    opset_imports: List[onnx.OperatorSetIdProto],
+    graph_name: str,
+    producer_name: Optional[str] = None,
+) -> onnx.ModelProto:
+    graph = onnx.helper.make_graph(
+        nodes=nodes, inputs=inputs, outputs=outputs, initializer=initializers, name=graph_name
+    )
+    model = onnx.helper.make_model(graph, opset_imports=opset_imports, producer_name=producer_name)
+    check_onnx(model)
+    return model
+
+
+def check_onnx(model: onnx.ModelProto) -> None:
+    model = copy.deepcopy(model)
+    if model.ByteSize() < onnx.checker.MAXIMUM_PROTOBUF:
+        onnx.checker.check_model(model, full_check=True)
+    else:
+        with tempfile.NamedTemporaryFile(suffix=".onnx") as file:
+            tmp_onnx_path = file.name
+        save_onnx(model, tmp_onnx_path)
+        onnx.checker.check_model(tmp_onnx_path, full_check=True)
+
+
+def forward_onnx(
+    model: onnx.ModelProto,
+    input_data: Optional[onnxsim.Tensors] = None,
+    input_shapes: Optional[onnxsim.TensorShapes] = None,
+    outputs: Optional[Sequence[str]] = None,
+    custom_lib: Optional[str] = None,
+    sess: Optional[ort.InferenceSession] = None,
+) -> onnxsim.Tensors:
+    if outputs is not None and len(outputs) == 0:
+        return {}
+    if input_shapes is None:
+        input_shapes = {}
+
+    if sess is None:
+        sess_options = ort.SessionOptions()
+        if custom_lib is not None:
+            if os.path.exists(custom_lib):
+                sess_options.register_custom_ops_library(custom_lib)
+            else:
+                print("No such file '{}'".format(custom_lib), file=sys.stderr)
+                exit(1)
+
+        sess_options.graph_optimization_level = ort.GraphOptimizationLevel(0)
+        sess_options.log_severity_level = 3
+        sess = initiate_onnxruntime_session(model, sess_options)
+
+    input_names = onnxsim.get_input_names(model)
+    inputs = {}
+    for name in input_names:
+        if input_data is not None and input_data.get(name, None) is not None:
+            inputs[name] = input_data[name]
+        else:
+            if input_shapes is not None and input_shapes.get(name, None) is not None:
+                shape = input_shapes[name]
+            else:
+                shape = onnxsim.get_shape(model, name)
+            inputs.update(onnxsim.generate_specific_rand_input(model, {name: shape}))
+
+    if not outputs:
+        outputs = [x.name for x in sess.get_outputs()]
+    run_options = ort.RunOptions()
+    run_options.log_severity_level = 3
+    res = OrderedDict(zip(outputs, sess.run(outputs, inputs, run_options=run_options)))
+    return res
+
+
+def move_initializer_to_input(model: onnx.ModelProto) -> onnx.ModelProto:
+    grpah_inputs = []
+    for init in model.graph.initializer:
+        np_array = onnx.numpy_helper.to_array(init)
+        grpah_inputs.append(
+            onnx.helper.make_tensor_value_info(
+                init.name, onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[np_array.dtype], [*np_array.shape]
+            )
+        )
+    model.graph.input.extend(grpah_inputs)
+    model.graph.ClearField("initializer")
+    return model
+
+
+def get_subgraphs(model: onnx.ModelProto) -> onnx.AttributeProto.GRAPHS:
+    subgraphs = []
+    for node in model.graph.node:
+        if onnxsim.has_subgraph_in_node(node):
+            for attr in node.attribute:
+                subgraphs.append(attr.g)
+    return subgraphs
+
+
+def make_dynamic_axis_fixed(value_info: onnx.ValueInfoProto, dim_param, dim_value) -> None:
+    for dim in value_info.type.tensor_type.shape.dim:
+        if dim.dim_param == dim_param:
+            dim.dim_value = dim_value
+
+
+def has_dynamic_axis(value_info: onnx.ValueInfoProto) -> bool:
+    return any(dim.dim_param for dim in value_info.type.tensor_type.shape.dim)
+
+
+def initiate_onnxruntime_session(
+    model: onnx.ModelProto, sess_options: ort.SessionOptions
+) -> ort.InferenceSession:
+    model = copy.deepcopy(model)
+    if model.ByteSize() < onnx.checker.MAXIMUM_PROTOBUF:
+        sess = ort.InferenceSession(
+            model.SerializeToString(), sess_options=sess_options, providers=["CPUExecutionProvider"]
+        )
+    else:
+        with tempfile.NamedTemporaryFile(suffix=".onnx") as file:
+            tmp_onnx_path = file.name
+        save_onnx(model, tmp_onnx_path)
+        sess = ort.InferenceSession(
+            tmp_onnx_path, sess_options=sess_options, providers=["CPUExecutionProvider"]
+        )
+    return sess
+
+
+def optimize_with_onnxruntime(model: onnx.ModelProto) -> onnx.ModelProto:
+    with tempfile.NamedTemporaryFile(suffix=".onnx") as file:
+        opt_onnx_path = file.name
+    save_onnx(model, opt_onnx_path)
+
+    sess_options = ort.SessionOptions()
+    # Set graph optimization level
+    sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_BASIC
+    sess_options.log_severity_level = 3
+    # To enable model serialization after graph optimization
+    sess_options.optimized_model_filepath = opt_onnx_path
+    _ = ort.InferenceSession(
+        opt_onnx_path, sess_options=sess_options, providers=["CPUExecutionProvider"]
+    )
+
+    model_opt = load_onnx(opt_onnx_path)
+    return model_opt
+
+
+def check_non_negative(value) -> int:
+    ivalue = int(value)
+    if ivalue < 0:
+        raise argparse.ArgumentTypeError("%s is an invalid negative int value" % value)
+    return ivalue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-[tool.black]
-line-length = 119
-target-version = ['py37']
-
 [tool.ruff]
 # Never enforce `E501` (line length violations).
 ignore = ["C901", "E501", "E741", "W605"]
@@ -40,3 +36,47 @@ markers = [
     "fp16",
     "quantization",
 ]
+
+# FuriosaAI pyproject.toml
+[tool.black]
+line-length = 100
+
+[tool.isort]
+force_sort_within_sections = true
+known_first_party = ['furiosa']
+line_length = 100
+profile = 'black'
+
+[[tool.mypy.overrides]]
+module = [
+    'PIL.*',
+    'cv2.*',
+    'onnx.*', # https://github.com/onnx/onnx/pull/3939
+    'tf2onnx.*',
+    'torchvision.*', # https://github.com/pytorch/vision/issues/2025
+    'tqdm.*',
+]
+ignore_missing_imports = true
+
+[tool.pylint.format]
+max-line-length = 100
+
+[tool.pylint.master]
+load-plugins = ['pylint_protobuf']
+
+[tool.pylint.message_control]
+disable = [
+    # Warning
+    'fixme', # W0511
+
+    # Convention
+    'line-too-long', # C0301
+    'missing-function-docstring', # C0116
+    'missing-module-docstring', # C0114
+
+    # Refactor
+    'duplicate-code', # R0801
+]
+
+[tool.pylint.typecheck]
+generated-members =['cv2.*', 'torch.*']

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ REQUIRED_PKGS = [
     "furiosa-sdk",
     "onnx",
     "onnxsim",
+    "onnxoptimizer",
     "onnxruntime",
 ]
 


### PR DESCRIPTION
# 용어
- gen-step: "generation step" 의 줄임말로서, text generation 에서 한 단위의 토큰을 생성하는 각 단계를 의미한다. pre-fill phase 의 경우는 `gen-step=0` 이며, 이후 decode phase 의 경우는 `gen-step=1, 2, 3...` 이다. 참고로 `max(generation_step) = max_new_tokens` 이다. 
  - max_new_tokens: https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationConfig.max_new_tokens
  - generation step 이라는 표현은 huggingface 의 문서에 등장한다. https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.TFGenerationMixin.compute_transition_scores.scores 등.
- decode_model_merged.onnx: huggingface 의 `text-generation-with-past` task 로 모델 export 를 하게되면 생성되는 출력 모델이다. 이 모델은 pre-fill phase 의 decode_model.onnx 와 decode phase 의 decode_model_with_past.onnx 를 sub-graph 형태로 병합한  그래프로 구성된다. 각 sub-graph 는 공통된 초기값을 가지므로 두 그래프를 병합함으로써 모델 바이너리 사이즈의 증가는 없다. 또한, dynamic axis 를 사용하므로 variable input length 및 variable gen-step 의 text-generation 과정을 하나의 단일한 ONNX 모델로 표현 가능하다.
- decoder_model-opt_gen_step={}.onnx
  - opt: `Shape` 오퍼레이터를 포함하여 constant folding 가능한 모든 graph 패턴이 간소화되어 있다. 또한 ONNX opset_version=13 하에서 elimination 과 fusing 도 적용되어 있다. 마지막으로 모든 tensor 의 입출력 값이 fixed shape 으로 추론되어 있는 그래프를 의미한다.
  - `gen_step={}` 은 각 generation step 을 의미한다. "gen-step" 항목의 설명 참조.

# 동작 방식
- huggingface `transformers` 와 `optimum` 을 베이스로 동작한다.
  - `optimum` 에서는 pt -> onnx export 기능을, `transformers` 에서는 onnx export 대상이 되는 모델을 가져온다.
- `optimum.litmus` 경로에는 onnx export, onnx simplification/optimization, compilation 관련 일반적인 기능이 구현되어 있다.
- `optimum.litmus.nlp` 경로에는 task-specific 한 기능이 구현되어 있다.
- "generation-step-wise ONNX graph generation": text-generation 은 decode phase 를 포함하고 있기 때문에 동적으로 동작한다. 즉, 각 generation step 별로 추론해야할 shape 들이 다르기 때문에, 정적 tensor shape 을 각 step 별로 추론하고 onnx graph 를 생성하는 방식으로 동작한다. 

# 모델
아래 링크의 google drive "decoder_model-opt_gen_step={}.onnx" ONNX 파일
- gpt2: https://furiosa-ai.atlassian.net/jira/software/c/projects/SWPROJ/boards/2/timeline?selectedIssue=SWPROJ-81
- gpt-neo: https://furiosa-ai.atlassian.net/jira/software/c/projects/SWPROJ/boards/2/timeline?selectedIssue=SWPROJ-80
- llama: https://furiosa-ai.atlassian.net/jira/software/c/projects/SWPROJ/boards/2/timeline?selectedIssue=SWPROJ-85
- opt: TBA


# 보완할 점
- LLaMA 13b 이상 모델 OOM
- OPT gen-step 1 부터 shape inference error
- 모델이 커질 수록 graph generation 시간이 오래 걸린다. 특히, ONNX save/load 가 빈번하여 "large" 모델의 경우 그 시간이 오래 걸림
- temp. 파일이 /tmp 경로에 빈번하게 저장되어 사이즈가 큰 모델(수십 GB)의 경우 disk space 부족할 수도 있음
